### PR TITLE
Remove activeadmin version requirements

### DIFF
--- a/crowdai_admin.gemspec
+++ b/crowdai_admin.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
-  s.add_dependency 'activeadmin', ['>= 1.1.0', '< 2.0']
+  s.add_dependency 'activeadmin', '>= 1.1.0'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'font-awesome-rails', '~> 4.7.0.4'
 end


### PR DESCRIPTION
**What**

This PR removes activeadmin version requirements in gemspec file.

**Why**

We need to update activeadmin gem in AICrowd repository in order to update rails to version 6.0.x.